### PR TITLE
<feat> dev 용 application.yml 파일 작성

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -22,9 +22,10 @@ jobs:
 
       - name: .env 파일 생성
         run: |
-          echo "KAKAO_APP_KEY=${{ secrets.KAKAO_APP_KEY }}" > .env
-          echo "KAKAO_REDIRECT_URL_LOCAL=${{ secrets.KAKAO_REDIRECT_URL_LOCAL }}$" >> .env
-          echo "JWT_TOKEN_SECRET_KEY=${{ secrets.JWT_TOKEN_SECRET_KEY }}$" >> .env
+          echo "JWT_TOKEN_SECRET_KEY=${{ secrets.JWT_TOKEN_SECRET_KEY }}" > .env
+          echo "DEV_MYSQL_URL=${{ secrets.DEV_MYSQL_URL }}$" >> .env
+          echo "DEV_MYSQL_USER_NAME=${{ secrets.DEV_MYSQL_USER_NAME }}$" >> .env
+          echo "DEV_MYSQL_PASSWORD=${{ secrets.DEV_MYSQL_PASSWORD }}$" >> .env
 
       - name: 빌드 및 테스트
         run: ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -1,45 +1,45 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.2'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.dongbaeb'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
-//	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	implementation "io.jsonwebtoken:jjwt-api:0.12.3"
-	runtimeOnly "io.jsonwebtoken:jjwt-gson:0.12.3"
-	runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.3"
+    implementation "io.jsonwebtoken:jjwt-api:0.12.3"
+    runtimeOnly "io.jsonwebtoken:jjwt-gson:0.12.3"
+    runtimeOnly "io.jsonwebtoken:jjwt-impl:0.12.3"
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,4 @@
-server:
-  port: 8081
+# common
 oauth:
   kakao:
     user-info-request-url: https://kapi.kakao.com/v2/user/me
@@ -9,5 +8,50 @@ spring:
 application:
   name: DongBaeb
 jwt:
-  secret-key: ${JWT_TOKEN_SECRET_KEY}
   access-expiration: 1800000
+---
+# dev
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DEV_MYSQL_URL}
+    username: ${DEV_MYSQL_USER_NAME}
+    password: ${DEV_MYSQL_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    properties:
+      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+server:
+  port: 8080
+jwt:
+  secret-key: ${JWT_TOKEN_SECRET_KEY}
+---
+# local
+spring:
+  config:
+    activate:
+      on-profile: local
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:dongbaeb
+    username: sa
+  jpa:
+    properties:
+      hibernate:
+        ddl-auto: create-drop
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+server:
+  port: 8081
+jwt:
+  secret-key: JSON_WEB_TOKEN_SECRET_KEY_FOR_LOCAL_PROFILE
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,9 +2,6 @@ server:
   port: 8081
 oauth:
   kakao:
-    app-key: ${KAKAO_APP_KEY}
-    redirect-url: ${KAKAO_REDIRECT_URL_LOCAL}
-    access-token-request-url: https://kauth.kakao.com/oauth/token
     user-info-request-url: https://kapi.kakao.com/v2/user/me
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,4 +54,27 @@ server:
   port: 8081
 jwt:
   secret-key: JSON_WEB_TOKEN_SECRET_KEY_FOR_LOCAL_PROFILE
-
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:dongbaeb
+    username: sa
+  jpa:
+    properties:
+      hibernate:
+        ddl-auto: create-drop
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+server:
+  port: 8082
+jwt:
+  secret-key: JSON_WEB_TOKEN_SECRET_KEY_FOR_TEST_PROFILE

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,10 @@ spring:
     username: ${DEV_MYSQL_USER_NAME}
     password: ${DEV_MYSQL_PASSWORD}
   jpa:
-    hibernate:
-      ddl-auto: none
     properties:
-      dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        ddl-auto: none
 server:
   port: 8080
 jwt:

--- a/src/test/java/com/dongbaeb/demo/DongbaebApplicationTests.java
+++ b/src/test/java/com/dongbaeb/demo/DongbaebApplicationTests.java
@@ -2,12 +2,14 @@ package com.dongbaeb.demo;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class DongbaebApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }


### PR DESCRIPTION
### 작업 상세 내용
- local, dev, test 프로필 분리
- ec2 에 mysql 서버 설치
  - mysql user 생성 및 권한 부여
  - mysql에 데이터베이스 및 테이블 생성
  - mysql 문자 인코딩 방식을 utf8mb4로 변경
- 어플리케이션 서버에 `api-dev.dongbaeb.site` 도메인 주소 부여
- ec2에 어플리케이션 배포

### 주의 사항
- local에서 어플리케이션을 실행할 때 profile 설정을 local로 설정하셔야 정상적으로 돌아갑니다.
- dev 서버에서 어플리케이션을 직접 빌드합니다.
  - 어플리케이션을 직접 빌드하는 것이 ec2에게 버거운 작업이라 새로운 방법을 모색해야 합니다.
- 환경 변수가 변경되었으니 .env 에 반영하시길 바랍니다.
  - 환경변수 관리 포인트가 벌써 5 곳(dev .env 파일, local .env 파일, 노션, 깃허브 액션 yml, 깃허브 액션 secrets) 이나 되기 때문에 개선 방법이 필요해 보입니다.